### PR TITLE
fix: GitHub Actions에서 base branch 명시적 fetch

### DIFF
--- a/.github/workflows/validate-articles.yml
+++ b/.github/workflows/validate-articles.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }} --depth=1 || true
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## 문제

PR 이벤트에서 validate:articles 스크립트가 실패:
```
fatal: ambiguous argument 'main...HEAD': unknown revision or path not in the working tree.
```

원인: GitHub Actions에서 checkout 후 base branch(main/release)가 로컬에 fetch되지 않아서 `git diff main...HEAD` 명령이 실패

## 해결

워크플로우의 Checkout 후 base branch를 명시적으로 fetch:
```yaml
- name: Fetch base branch
  run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }} --depth=1 || true
```

- `github.base_ref`: PR의 target branch (main 또는 release)
- `|| true`: 로컬 테스트 환경에서 실패해도 무시 (환경 변수 미설정 시)

## 영향

- ✅ PR 이벤트에서 validate:articles 정상 작동
- ✅ 로컬 환경에는 영향 없음 (GITHUB_BASE_REF 미설정 시 fallback)
- ✅ 기존 테스트 모두 통과

Closes #13