### PR TITLE
fix: generateStaticParams와 충돌하는 revalidate 설정 제거

### DIFF
--- a/src/app/(routes)/articles/[slug]/page.tsx
+++ b/src/app/(routes)/articles/[slug]/page.tsx
@@ -28,8 +28,6 @@ export function generateStaticParams() {
   }));
 }
 
-export const revalidate = 60 * 60;
-
 export async function generateMetadata({
   params,
 }: ArticlePageProps): Promise<Metadata> {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

없음 (Vercel 배포 빌드 오류 핫픽스)

---

## 💡 어떤 것, 어떻게 해결했는가? (What & How)

### 문제
Vercel 배포 시 아래 오류로 빌드 실패:
\`\`\`
Invalid segment configuration export detected.
\`\`\`

### 원인
`src/app/(routes)/articles/[slug]/page.tsx`에서 `generateStaticParams()`와 `export const revalidate`를 함께 선언하면 Next.js가 설정 충돌로 판단

- `generateStaticParams()` → 빌드 타임 정적 페이지 생성 (SSG)
- `export const revalidate` → 런타임 재검증 (ISR)

`generateStaticParams()`가 있으면 Next.js가 자동으로 ISR을 처리하므로 `revalidate`를 별도로 선언할 필요가 없음

### 해결
`export const revalidate = 60 * 60;` 제거

---

## 😊 코멘트 (Comment)

`generateStaticParams()`만 있어도 빌드 타임 사전 생성 + 수정 시 자동 갱신이 동작합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 개요

이 PR은 Next.js의 `generateStaticParams()`와 `export const revalidate` 설정의 충돌로 인한 Vercel 빌드 오류를 해결하는 버그 수정입니다. `src/app/(routes)/articles/[slug]/page.tsx`에서 `revalidate = 60 * 60` 상수 선언을 제거했습니다.

## 기술적 근거

- **Next.js 설정 규칙**: `generateStaticParams()`가 존재하면 Next.js는 자동으로 ISR(Incremental Static Regeneration)을 처리하므로 별도의 `revalidate` 선언이 불필요합니다.
- **해결된 문제**: 동시 선언으로 인한 "Invalid segment configuration export detected" 빌드 에러가 제거됩니다.
- **변경 사항**: 2줄 제거로 최소한의 수정 범위를 유지합니다.

## 검토 결과

모든 검토 항목에서 이상이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->