### PR TITLE
fix: 홈 데스크 이미지가 넓은 뷰포트에서 main 영역을 벗어나는 오류 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-blog",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "generate:index": "node scripts/generate-article-index.js",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import { ROUTES } from "@/constants/paths";
 
 export default function Home() {
   return (
-    <div className="absolute top-1/2 -translate-y-1/2">
+    <div className="absolute left-1/2 top-1/2 w-full -translate-x-1/2 -translate-y-1/2 px-lg md:px-xl">
       <div className="relative w-full">
         <Image
           src={DeskBgImage}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

Closes #27

---

## 💡 어떤 것, 어떻게 해결했는가? (What & How)

- `src/app/page.tsx` 최상위 래퍼에서 수평 중앙 정렬 클래스 누락으로 인해 뷰포트가 1000px 이상일 때 데스크 이미지가 `main` 영역을 벗어나는 문제 수정
- `left-1/2`, `-translate-x-1/2` 추가로 수평 중앙 정렬 복원
- `w-full`, `px-lg md:px-xl` 추가로 너비 및 패딩 기준 명시
