### PR TITLE
release: v1.0.2 — 홈 데스크 이미지 레이아웃 핫픽스

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-blog",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "generate:index": "node scripts/generate-article-index.js",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import { ROUTES } from "@/constants/paths";
 
 export default function Home() {
   return (
-    <div className="absolute top-1/2 -translate-y-1/2">
+    <div className="absolute left-1/2 top-1/2 w-full -translate-x-1/2 -translate-y-1/2 px-lg md:px-xl">
       <div className="relative w-full">
         <Image
           src={DeskBgImage}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

Closes #27

---

## 💡 어떤 것, 어떻게 해결했는가? (What & How)

main → release 핫픽스 반영 (#28)

### 포함된 변경사항
- `fix: 홈 데스크 이미지가 넓은 뷰포트에서 main 영역을 벗어나는 오류 수정` (#28)
  - `flex-1` 및 `absolute` 포지셔닝 설정으로 인해 뷰포트 1000px 이상에서 데스크 이미지가 `main` 영역을 벗어나는 문제
  - 최상위 래퍼에 `left-1/2`, `-translate-x-1/2`, `w-full`, `px-lg md:px-xl` 추가로 수평 중앙 정렬 및 너비 기준 복원

---

## 📚 구현하면서 학습한 내용 (What I Learned)

-

---

## 😊 코멘트 (Comment)

-