### PR TITLE
fix: validate-articles CI - GITHUB_BASE_REF origin/ 프리픽스 누락 수정

### DIFF
--- a/scripts/validate-articles.ts
+++ b/scripts/validate-articles.ts
@@ -12,9 +12,12 @@ interface ValidationResult {
 }
 
 const getChangedArticleSlugs = (): string[] => {
-  // GITHUB_BASE_REF: GitHub Actions에서 제공하는 기본 브랜치 (main, release 등)
+  // GITHUB_BASE_REF: GitHub Actions에서 제공하는 기본 브랜치명 (main, release 등)
+  // CI 환경: origin/<브랜치명> 형태로 참조 (fetch된 remote 브랜치 사용)
   // 로컬 환경: undefined → origin/main을 기본값으로 사용
-  const baseRef = process.env.GITHUB_BASE_REF || "origin/main";
+  const baseRef = process.env.GITHUB_BASE_REF
+    ? `origin/${process.env.GITHUB_BASE_REF}`
+    : "origin/main";
 
   try {
     // article-index.json에서 등록된 아티클 목록 읽기


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

Closes #32

---

## 💡 어떤 것, 어떻게 해결했는가? (What & How)

- CI에서 `yarn validate:articles` 실행 시 `fatal: release...HEAD: no merge base` 오류 발생
- 원인: `GITHUB_BASE_REF`가 `release` 브랜치명만 반환하는데, `git diff release...HEAD`에서 로컬에 해당 브랜치가 없어 merge base를 찾지 못함
- 해결: `GITHUB_BASE_REF` → `origin/${GITHUB_BASE_REF}` 형태로 참조하여 fetch된 remote 브랜치를 직접 사용

---

## 📚 구현하면서 학습한 내용 (What I Learned)

-

---

## 😊 코멘트 (Comment)

-